### PR TITLE
Update DM300.java

### DIFF
--- a/core/src/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM300.java
+++ b/core/src/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM300.java
@@ -54,6 +54,7 @@ import com.watabou.utils.Random;
 import java.util.HashSet;
 
 public class DM300 extends Mob {
+	private int healFactor=1;
 	
 	{
 		spriteClass = DM300Sprite.class;
@@ -63,7 +64,7 @@ public class DM300 extends Mob {
 		defenseSkill = 18;
 		
 		loot = new CapeOfThorns().identify();
-		lootChance = 0.333f;
+		lootChance = 0.4f;
 
 		properties.add(Property.BOSS);
 	}
@@ -97,8 +98,10 @@ public class DM300 extends Mob {
 		
 		if (Dungeon.level.map[step] == Terrain.INACTIVE_TRAP && HP < HT) {
 			
-			HP += Random.Int( 1, HT - HP );
+			HP += 1 + (int)(Random.Int( 1, HT - HP ) / healFactor);
+			HP= HP >= HT ? HT : HP
 			sprite.emitter().burst( ElmoParticle.FACTORY, 5 );
+			healFactor=(++healFactor)>=6?6:healFactor; 
 			
 			if (Dungeon.visible[step] && Dungeon.hero.isAlive()) {
 				GLog.n( Messages.get(this, "repair") );


### PR DESCRIPTION
- Chance to drop Cape of Thrones increased to 40%, up from 33.3%.
- Each heal reduces next heal proportionally to the amount of times DM300 has already healed, up to a reduction of a 83% (Normal healing for first heal, 1/2 effect for second heal, 1/3 for third, and so on) Minimum heal of 1HP.